### PR TITLE
refactor: compare prototype using getPrototypeOf

### DIFF
--- a/packages/runtime/src/exports.spec.mts
+++ b/packages/runtime/src/exports.spec.mts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { createExports, isExports } from './exports.js';
+
+describe('exports', () => {
+  it('should match snapshot', () => {
+    expect(createExports()).toMatchInlineSnapshot(`{}`);
+  });
+
+  describe('isExports', () => {
+    it('should return `true` if provided object was created using `createExports()`', () => {
+      const value = createExports();
+      expect(isExports(value)).toBe(true);
+    });
+
+    it('should return `false` if provided value is plain object', () => {
+      const value = {};
+      expect(isExports(value)).toBe(false);
+    });
+  });
+});

--- a/packages/runtime/src/exports.ts
+++ b/packages/runtime/src/exports.ts
@@ -1,0 +1,12 @@
+import { Exports } from './types';
+
+// An object used to compare prototype reference equality.
+const __ref = {};
+
+export function createExports(): Exports {
+  return Object.create(__ref) as Exports;
+}
+
+export function isExports<T>(object: T): boolean {
+  return Object.getPrototypeOf(object) === __ref;
+}

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -1,7 +1,6 @@
-export const __hasOwnProp = Object.prototype.hasOwnProperty;
-export const __defProp = Object.defineProperty;
-
-export const __copyProps = <T extends object>(
+const __hasOwnProp = Object.prototype.hasOwnProperty;
+const __defProp = Object.defineProperty;
+const __copyProps = <T extends object>(
   destination: T,
   source: T,
   except?: string,
@@ -20,4 +19,10 @@ export const __copyProps = <T extends object>(
   }
 
   return destination;
+};
+
+export {
+  __hasOwnProp as hasOwnProp,
+  __defProp as depProp,
+  __copyProps as copyProps,
 };

--- a/packages/runtime/src/utils.ts
+++ b/packages/runtime/src/utils.ts
@@ -1,6 +1,6 @@
-const __hasOwnProp = Object.prototype.hasOwnProperty;
-const __defProp = Object.defineProperty;
-const __copyProps = <T extends object>(
+const hasOwnProp = Object.prototype.hasOwnProperty;
+const defProp = Object.defineProperty;
+const copyProps = <T extends object>(
   destination: T,
   source: T,
   except?: string,
@@ -8,10 +8,10 @@ const __copyProps = <T extends object>(
   for (const key in source) {
     if (
       key !== except &&
-      __hasOwnProp.call(source, key) &&
-      !__hasOwnProp.call(destination, key)
+      hasOwnProp.call(source, key) &&
+      !hasOwnProp.call(destination, key)
     ) {
-      __defProp(destination, key, {
+      defProp(destination, key, {
         enumerable: true,
         get: () => source[key],
       });
@@ -21,8 +21,4 @@ const __copyProps = <T extends object>(
   return destination;
 };
 
-export {
-  __hasOwnProp as hasOwnProp,
-  __defProp as depProp,
-  __copyProps as copyProps,
-};
+export { hasOwnProp, defProp, copyProps };


### PR DESCRIPTION
# Description

```js
// Before
function Foo() {}

const exports = new Foo();
const isExports = exports instanceof Foo;

// After
const __ref = {};

const exports = Object.create(__ref);
const isExports = Object.getPrototypeOf(exports) === __ref;
```
