### PR TITLE
feat(swc-plugin): support computed exports

### DIFF
--- a/packages/swc-plugin/transform/tests/fixture/bundle/cjs_exports/input.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/cjs_exports/input.js
@@ -5,6 +5,6 @@ exports.baz = 'baz';
 module.exports = 'default';
 module.exports.foo = 'foo';
 module.exports.bar = 'bar';
-module.exports.baz = 'baz';
+module.exports['baz'] = 'baz';
 
 Object.assign(module.exports, {});

--- a/packages/swc-plugin/transform/tests/fixture/bundle/cjs_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/cjs_exports/output.js
@@ -5,5 +5,5 @@ exports.baz = __ctx.module.exports.baz = 'baz';
 module.exports = __ctx.module.exports = 'default';
 module.exports.foo = __ctx.module.exports.foo = 'foo';
 module.exports.bar = __ctx.module.exports.bar = 'bar';
-module.exports.baz = __ctx.module.exports.baz = 'baz';
+module.exports['baz'] = __ctx.module.exports.baz = 'baz';
 Object.assign(module.exports = __ctx.module.exports, {});


### PR DESCRIPTION

```js
# AS-IS
exports['foo'] = 1; // panic!

# TO-BE
exports['foo'] = __ctx.module.exports.foo = 1;
```