### PR TITLE
fix(swc-plugin): separate declaration stmts and assign exprs

### DIFF
--- a/packages/swc-plugin/transform/src/delegate/bundle_delegate.rs
+++ b/packages/swc-plugin/transform/src/delegate/bundle_delegate.rs
@@ -61,7 +61,7 @@ impl AstDelegate for BundleDelegate {
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem {
         let item = get_from_export_decl(export_decl);
         self.exps.push(item.export_ref);
-        self.bindings.push(item.binding_stmt);
+        self.bindings.extend(item.binding_stmts);
 
         item.export_stmt
     }

--- a/packages/swc-plugin/transform/src/delegate/bundle_delegate.rs
+++ b/packages/swc-plugin/transform/src/delegate/bundle_delegate.rs
@@ -23,6 +23,7 @@ pub struct BundleDelegate {
     id: f64,
     ctx_ident: Ident,
     exps: Vec<ExportRef>,
+    hoisted_decls: Vec<ModuleItem>,
     bindings: Vec<ModuleItem>,
 }
 
@@ -32,6 +33,7 @@ impl BundleDelegate {
             id,
             ctx_ident: private_ident!("__ctx"),
             exps: Vec::default(),
+            hoisted_decls: Vec::default(),
             bindings: Vec::default(),
         }
     }
@@ -47,20 +49,35 @@ impl AstDelegate for BundleDelegate {
 
     fn make_module_body(&mut self, orig_body: Vec<ModuleItem>) -> Vec<ModuleItem> {
         let exps = mem::take(&mut self.exps);
+        let hoisted_decls = mem::take(&mut self.hoisted_decls);
         let bindings = mem::take(&mut self.bindings);
         let ExportsAst {
             leading_body,
             trailing_body,
         } = exports_to_ast(&self.ctx_ident, exps, crate::phase::ModulePhase::Bundle);
 
-        let mut new_body: Vec<ModuleItem> = vec![];
+        let mut stmts = Vec::with_capacity(orig_body.len());
+        let mut imports = Vec::with_capacity(orig_body.len());
+        let mut exports = Vec::with_capacity(orig_body.len());
+        let mut new_body: Vec<ModuleItem> = Vec::with_capacity(
+            1 + leading_body.len() + orig_body.len() + bindings.len() + trailing_body.len(),
+        );
         new_body.push(global_module_register_stmt(self.id, &self.ctx_ident).into());
         new_body.extend(leading_body);
+        new_body.extend(hoisted_decls);
         new_body.extend(orig_body);
         new_body.extend(bindings);
         new_body.extend(trailing_body);
 
-        new_body
+        new_body.into_iter().for_each(|item| match item {
+            ModuleItem::ModuleDecl(ref module_decl) => match module_decl {
+                ModuleDecl::Import(_) => imports.push(item),
+                _ => exports.push(item),
+            },
+            ModuleItem::Stmt(_) => stmts.push(item),
+        });
+
+        [imports, stmts, exports].concat()
     }
 
     fn import(&mut self, _: &ImportDecl) {}
@@ -68,7 +85,8 @@ impl AstDelegate for BundleDelegate {
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem {
         let item = get_from_export_decl(export_decl);
         self.exps.push(item.export_ref);
-        self.bindings.extend(item.binding_stmts);
+        self.hoisted_decls.push(export_decl.decl.clone().into());
+        self.bindings.push(item.binding_stmt);
 
         item.export_stmt
     }
@@ -79,30 +97,32 @@ impl AstDelegate for BundleDelegate {
     ) -> Option<ModuleItem> {
         let ident = get_ident_from_default_decl(&export_default_decl.decl);
         let binding_export = BindingExportMember::new("default".into());
-        let stmts = match ident {
-            Some(ident) => {
-                vec![
-                    into_decl(&export_default_decl.decl).into(),
-                    assign_expr(binding_export.bind_ident.clone(), ident.into())
-                        .into_stmt()
-                        .into(),
-                ]
-            }
-            None => vec![assign_expr(
-                binding_export.bind_ident.clone(),
-                get_expr_from_default_decl(&export_default_decl.decl).into(),
-            )
-            .into_stmt()
-            .into()],
-        };
-
         let binding_export_stmt =
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
                 span: DUMMY_SP,
                 expr: Box::new(binding_export.bind_ident.clone().into()),
             }));
 
-        self.bindings.extend(stmts);
+        match ident {
+            Some(ident) => {
+                self.hoisted_decls
+                    .push(into_decl(&export_default_decl.decl).into());
+                self.bindings.push(
+                    assign_expr(binding_export.bind_ident.clone(), ident.into())
+                        .into_stmt()
+                        .into(),
+                );
+            }
+            None => self.bindings.push(
+                assign_expr(
+                    binding_export.bind_ident.clone(),
+                    get_expr_from_default_decl(&export_default_decl.decl).into(),
+                )
+                .into_stmt()
+                .into(),
+            ),
+        };
+
         self.exps.push(ExportRef::Named(NamedExportRef::new(vec![
             ExportMember::Binding(binding_export),
         ])));

--- a/packages/swc-plugin/transform/src/delegate/runtime_delegate.rs
+++ b/packages/swc-plugin/transform/src/delegate/runtime_delegate.rs
@@ -30,6 +30,7 @@ pub struct RuntimeDelegate {
     ctx_ident: Ident,
     deps: OHashMap<Atom, ModuleRef>,
     exps: Vec<ExportRef>,
+    hoisted_decls: Vec<ModuleItem>,
     bindings: Vec<ModuleItem>,
 }
 
@@ -41,6 +42,7 @@ impl RuntimeDelegate {
             ctx_ident: private_ident!("__ctx"),
             deps: OHashMap::default(),
             exps: Vec::default(),
+            hoisted_decls: Vec::default(),
             bindings: Vec::default(),
         }
     }
@@ -56,6 +58,7 @@ impl AstDelegate for RuntimeDelegate {
 
     fn make_module_body(&mut self, mut orig_body: Vec<ModuleItem>) -> Vec<ModuleItem> {
         let exps = mem::take(&mut self.exps);
+        let hoisted_decls = mem::take(&mut self.hoisted_decls);
         let bindings = mem::take(&mut self.bindings);
 
         orig_body.retain(|item| item.is_stmt());
@@ -76,6 +79,7 @@ impl AstDelegate for RuntimeDelegate {
         new_body.push(global_module_get_ctx_stmt(self.id, &self.ctx_ident).into());
         new_body.extend(deps_items);
         new_body.extend(leading_body);
+        new_body.extend(hoisted_decls);
         new_body.extend(orig_body);
         new_body.extend(bindings);
         new_body.extend(trailing_body);
@@ -96,7 +100,8 @@ impl AstDelegate for RuntimeDelegate {
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem {
         let item = get_from_export_decl(export_decl);
         self.exps.push(item.export_ref);
-        self.bindings.extend(item.binding_stmts);
+        self.hoisted_decls.push(export_decl.decl.clone().into());
+        self.bindings.push(item.binding_stmt);
 
         item.export_stmt
     }
@@ -107,24 +112,27 @@ impl AstDelegate for RuntimeDelegate {
     ) -> Option<ModuleItem> {
         let ident = get_ident_from_default_decl(&export_default_decl.decl);
         let binding_export = BindingExportMember::new("default".into());
-        let stmts = match ident {
+
+        match ident {
             Some(ident) => {
-                vec![
-                    into_decl(&export_default_decl.decl).into(),
+                self.hoisted_decls
+                    .push(into_decl(&export_default_decl.decl).into());
+                self.bindings.push(
                     assign_expr(binding_export.bind_ident.clone(), ident.into())
                         .into_stmt()
                         .into(),
-                ]
+                );
             }
-            None => vec![assign_expr(
-                binding_export.bind_ident.clone(),
-                get_expr_from_default_decl(&export_default_decl.decl).into(),
-            )
-            .into_stmt()
-            .into()],
+            None => self.bindings.push(
+                assign_expr(
+                    binding_export.bind_ident.clone(),
+                    get_expr_from_default_decl(&export_default_decl.decl).into(),
+                )
+                .into_stmt()
+                .into(),
+            ),
         };
 
-        self.bindings.extend(stmts);
         self.exps.push(ExportRef::Named(NamedExportRef::new(vec![
             ExportMember::Binding(binding_export),
         ])));

--- a/packages/swc-plugin/transform/src/delegate/runtime_delegate.rs
+++ b/packages/swc-plugin/transform/src/delegate/runtime_delegate.rs
@@ -95,7 +95,7 @@ impl AstDelegate for RuntimeDelegate {
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem {
         let item = get_from_export_decl(export_decl);
         self.exps.push(item.export_ref);
-        self.bindings.push(item.binding_stmt);
+        self.bindings.extend(item.binding_stmts);
 
         item.export_stmt
     }

--- a/packages/swc-plugin/transform/src/delegate/traits.rs
+++ b/packages/swc-plugin/transform/src/delegate/traits.rs
@@ -5,7 +5,10 @@ pub trait AstDelegate {
     fn make_module_body(&mut self, orig_body: Vec<ModuleItem>) -> Vec<ModuleItem>;
     fn import(&mut self, import_decl: &ImportDecl);
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem;
-    fn export_default_decl(&mut self, export_default_decl: &ExportDefaultDecl) -> Option<ModuleItem>;
+    fn export_default_decl(
+        &mut self,
+        export_default_decl: &ExportDefaultDecl,
+    ) -> Option<ModuleItem>;
     fn export_default_expr(&mut self, export_default_expr: &ExportDefaultExpr) -> Expr;
     fn export_named(&mut self, export_named: &NamedExport);
     fn export_all(&mut self, export_all: &ExportAll);

--- a/packages/swc-plugin/transform/src/delegate/traits.rs
+++ b/packages/swc-plugin/transform/src/delegate/traits.rs
@@ -5,7 +5,7 @@ pub trait AstDelegate {
     fn make_module_body(&mut self, orig_body: Vec<ModuleItem>) -> Vec<ModuleItem>;
     fn import(&mut self, import_decl: &ImportDecl);
     fn export_decl(&mut self, export_decl: &ExportDecl) -> ModuleItem;
-    fn export_default_decl(&mut self, export_default_decl: &ExportDefaultDecl) -> ModuleItem;
+    fn export_default_decl(&mut self, export_default_decl: &ExportDefaultDecl) -> Option<ModuleItem>;
     fn export_default_expr(&mut self, export_default_expr: &ExportDefaultExpr) -> Expr;
     fn export_named(&mut self, export_named: &NamedExport);
     fn export_all(&mut self, export_all: &ExportAll);

--- a/packages/swc-plugin/transform/src/models.rs
+++ b/packages/swc-plugin/transform/src/models.rs
@@ -429,7 +429,7 @@ pub mod helpers {
                 span: DUMMY_SP,
             }))
             .into(),
-            binding_stmts: vec![export_decl.decl.clone().into(), binding_assign_stmt.into()],
+            binding_stmt: binding_assign_stmt.into(),
         }
     }
 
@@ -638,7 +638,7 @@ pub mod helpers {
 pub struct ExportDeclItem {
     pub export_ref: ExportRef,
     pub export_stmt: ModuleItem,
-    pub binding_stmts: Vec<ModuleItem>,
+    pub binding_stmt: ModuleItem,
 }
 
 pub struct ExportsAst {

--- a/packages/swc-plugin/transform/src/models.rs
+++ b/packages/swc-plugin/transform/src/models.rs
@@ -399,18 +399,17 @@ pub mod helpers {
         // `function foo {}`
         //
         // - `orig_ident`: `foo`
-        // - `decl_expr`: `function foo{}`
-        let (orig_ident, decl_expr) = get_expr_from_decl(&export_decl.decl);
+        let orig_ident = get_ident_from_decl(&export_decl.decl);
 
         // - `binding_name`: `__x`
         // - `exported_name`: `foo`
         let binding_export = BindingExportMember::new(orig_ident.sym.clone());
         let binding_name = ModuleExportName::Ident(binding_export.bind_ident.clone());
-        let exported_name = ModuleExportName::Ident(orig_ident);
+        let exported_name = ModuleExportName::Ident(orig_ident.clone());
 
         // `binding_assign_stmt`: `__x = function foo {}`
         let binding_assign_stmt =
-            assign_expr(binding_export.bind_ident.clone(), decl_expr).into_stmt();
+            assign_expr(binding_export.bind_ident.clone(), orig_ident.into()).into_stmt();
         let export_ref = ExportRef::Named(NamedExportRef::new(vec![ExportMember::Binding(
             binding_export,
         )]));
@@ -430,7 +429,7 @@ pub mod helpers {
                 span: DUMMY_SP,
             }))
             .into(),
-            binding_stmt: binding_assign_stmt.into(),
+            binding_stmts: vec![export_decl.decl.clone().into(), binding_assign_stmt.into()],
         }
     }
 
@@ -639,7 +638,7 @@ pub mod helpers {
 pub struct ExportDeclItem {
     pub export_ref: ExportRef,
     pub export_stmt: ModuleItem,
-    pub binding_stmt: ModuleItem,
+    pub binding_stmts: Vec<ModuleItem>,
 }
 
 pub struct ExportsAst {

--- a/packages/swc-plugin/transform/src/transformer.rs
+++ b/packages/swc-plugin/transform/src/transformer.rs
@@ -92,7 +92,11 @@ impl VisitMut for GlobalModuleTransformer {
                         ModuleDecl::ExportDefaultDecl(export_default_decl) => {
                             export_default_decl.visit_mut_children_with(self);
 
-                            *item = self.delegate.export_default_decl(export_default_decl)
+                            if let Some(new_item) =
+                                self.delegate.export_default_decl(export_default_decl)
+                            {
+                                *item = new_item;
+                            }
                         }
                         // Default export statements.
                         //

--- a/packages/swc-plugin/transform/src/utils.rs
+++ b/packages/swc-plugin/transform/src/utils.rs
@@ -331,39 +331,25 @@ pub mod ast {
         .into()
     }
 
-    /// Extracts and returns the expression with its ident from the declarations.
+    /// Extracts and returns the its ident from the declarations.
     ///
     /// ```js
     /// function foo {}
     /// class Bar {}
     /// const baz = expr;
     /// ```
-    pub fn get_expr_from_decl(decl: &Decl) -> (Ident, Expr) {
+    pub fn get_ident_from_decl(decl: &Decl) -> Ident {
         match decl {
             Decl::Class(ClassDecl {
                 class,
                 ident,
                 declare: false,
-            }) => (
-                ident.clone(),
-                ClassExpr {
-                    class: class.clone(),
-                    ident: Some(ident.clone()),
-                }
-                .into(),
-            ),
+            }) => ident.clone(),
             Decl::Fn(FnDecl {
                 function,
                 ident,
                 declare: false,
-            }) => (
-                ident.clone(),
-                FnExpr {
-                    function: function.clone(),
-                    ident: Some(ident.clone()),
-                }
-                .into(),
-            ),
+            }) => ident.clone(),
             Decl::Var(val_decl) => {
                 if val_decl.decls.len() != 1 {
                     panic!("invalid named exports");
@@ -377,7 +363,7 @@ pub mod ast {
                         init: Some(expr),
                         definite: false,
                         ..
-                    } => (id.clone(), *expr.clone()),
+                    } => id.clone(),
                     _ => panic!("invalid"),
                 }
             }

--- a/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
@@ -1,4 +1,3 @@
-var __ctx = global.__modules.register(1000);
 import * as __mod from "./re-exp";
 import * as __mod1 from "./re-exp-2";
 import * as __mod2 from "./re-exp-3";
@@ -9,6 +8,11 @@ import { foo } from './foo';
 import { bar as bar2 } from './bar';
 import * as baz from './baz';
 import * as foo2 from './foo';
+var __ctx = global.__modules.register(1000);
+const variable = 1;
+class Class {
+}
+function func() {}
 React.lazy(()=>import('./Component'));
 if (__DEV__) {
     require('./cjs-1');
@@ -19,24 +23,8 @@ module.exports.foo = __ctx.module.exports.foo = 2;
 Object.assign(module.exports = __ctx.module.exports, {
     bar: 1
 });
-export { __x as variable };
-export { __x1 as Class };
-export { __x2 as func };
-export default __x3;
-export { value as value2 };
-export { foo, foo2 };
-export { baz, baz as baz2 };
-export * from './re-exp';
-export * as rx from './re-exp-2';
-export { rx2 } from './re-exp-3';
-export { rx3 as rx4 } from './re-exp-4';
-export { default as rx5 } from './re-exp-5';
-const variable = 1;
 __x = variable;
-class Class {
-}
 __x1 = Class;
-function func() {}
 __x2 = func;
 __x3 = function() {
     require('./cjs-2');
@@ -64,3 +52,15 @@ __ctx.exports(function() {
     };
 });
 var __x, __x1, __x2, __x3;
+export { __x as variable };
+export { __x1 as Class };
+export { __x2 as func };
+export default __x3;
+export { value as value2 };
+export { foo, foo2 };
+export { baz, baz as baz2 };
+export * from './re-exp';
+export * as rx from './re-exp-2';
+export { rx2 } from './re-exp-3';
+export { rx3 as rx4 } from './re-exp-4';
+export { default as rx5 } from './re-exp-5';

--- a/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
@@ -37,10 +37,13 @@ export * as rx from './re-exp-2';
 export { rx2 } from './re-exp-3';
 export { rx3 as rx4 } from './re-exp-4';
 export { default as rx5 } from './re-exp-5';
-__x = 1;
-__x1 = class Class {
-};
-__x2 = function func() {};
+const variable = 1;
+__x = variable;
+class Class {
+}
+__x1 = Class;
+function func() {}
+__x2 = func;
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/all/output.js
@@ -22,13 +22,7 @@ Object.assign(module.exports = __ctx.module.exports, {
 export { __x as variable };
 export { __x1 as Class };
 export { __x2 as func };
-export default __x3 = function() {
-    require('./cjs-2');
-    const inner = async ()=>{
-        await import('./esm');
-        require('./cjs-3');
-    };
-};
+export default __x3;
 export { value as value2 };
 export { foo, foo2 };
 export { baz, baz as baz2 };
@@ -44,6 +38,13 @@ class Class {
 __x1 = Class;
 function func() {}
 __x2 = func;
+__x3 = function() {
+    require('./cjs-2');
+    const inner = async ()=>{
+        await import('./esm');
+        require('./cjs-3');
+    };
+};
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_class_decl/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_class_decl/output.js
@@ -1,5 +1,6 @@
 var __ctx = global.__modules.register(1000);
-export default __x = class {
+export default __x;
+__x = class {
 };
 __ctx.exports(function() {
     return {

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_class_decl/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_class_decl/output.js
@@ -1,5 +1,4 @@
 var __ctx = global.__modules.register(1000);
-export default __x;
 __x = class {
 };
 __ctx.exports(function() {
@@ -8,3 +7,4 @@ __ctx.exports(function() {
     };
 });
 var __x;
+export default __x;

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_expr/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_expr/output.js
@@ -1,8 +1,8 @@
 var __ctx = global.__modules.register(1000);
-export default __x = 'default';
 __ctx.exports(function () {
     return {
       "default": __x
     };
 });
 var __x;
+export default __x = 'default';

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_fn_decl/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_fn_decl/output.js
@@ -1,5 +1,4 @@
 var __ctx = global.__modules.register(1000);
-export default __x;
 __x = function() {};
 __ctx.exports(function() {
     return {
@@ -7,3 +6,4 @@ __ctx.exports(function() {
     };
 });
 var __x;
+export default __x;

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_fn_decl/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_default_export_fn_decl/output.js
@@ -1,5 +1,6 @@
 var __ctx = global.__modules.register(1000);
-export default __x = function() {};
+export default __x;
+__x = function() {};
 __ctx.exports(function() {
     return {
         "default": __x

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_exports/output.js
@@ -6,10 +6,13 @@ export { foo, bar, baz as named };
 export { __x as variable };
 export { __x1 as Class };
 export { __x2 as func };
-__x = 1;
-__x1 = class Class {
-};
-__x2 = function func() {};
+const variable = 1;
+__x = variable;
+class Class {
+}
+__x1 = Class;
+function func() {}
+__x2 = func;
 __ctx.exports(function() {
     return {
         "foo": foo,

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_exports/output.js
@@ -1,17 +1,12 @@
 var __ctx = global.__modules.register(1000);
-const foo = 'foo';
-const bar = 'bar';
-// Export named
-export { foo, bar, baz as named };
-export { __x as variable };
-export { __x1 as Class };
-export { __x2 as func };
 const variable = 1;
-__x = variable;
 class Class {
 }
-__x1 = Class;
 function func() {}
+const foo = 'foo';
+const bar = 'bar';
+__x = variable;
+__x1 = Class;
 __x2 = func;
 __ctx.exports(function() {
     return {
@@ -24,3 +19,8 @@ __ctx.exports(function() {
     };
 });
 var __x, __x1, __x2;
+// Export named
+export { foo, bar, baz as named };
+export { __x as variable };
+export { __x1 as Class };
+export { __x2 as func };

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_imports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_imports/output.js
@@ -1,5 +1,5 @@
-var __ctx = global.__modules.register(1000);
 import React, { useState, useCallback, useMemo as useMemoization } from 'react';
 import Default from 'mod-1';
 import { foo, bar, baz } from 'mod-2';
 import * as all from 'mod-3';
+var __ctx = global.__modules.register(1000);

--- a/packages/swc-plugin/transform/tests/fixture/bundle/esm_re_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/bundle/esm_re_exports/output.js
@@ -1,12 +1,8 @@
-var __ctx = global.__modules.register(1000);
 import * as __mod from "./mod-1";
 import * as __mod1 from "./mod-2";
 import * as __mod2 from "./mod-3";
 import * as __mod3 from "./mod-4";
-export * from './mod-1';
-export * as mod2 from './mod-2';
-export { foo, bar, baz } from './mod-3';
-export { default } from './mod-4';
+var __ctx = global.__modules.register(1000);
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),
@@ -17,3 +13,7 @@ __ctx.exports(function() {
         "default": __mod3.default
     };
 });
+export * from './mod-1';
+export * as mod2 from './mod-2';
+export { foo, bar, baz } from './mod-3';
+export { default } from './mod-4';

--- a/packages/swc-plugin/transform/tests/fixture/paths/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/paths/output.js
@@ -9,6 +9,10 @@ var __mod1 = global.__modules.require(1011);
 var __mod2 = global.__modules.require(1012);
 var __mod3 = global.__modules.require(1013);
 var __mod4 = global.__modules.require(1014);
+const variable = 1;
+class Class {
+}
+function func() {}
 React.lazy(()=>global.__modules.require(1004));
 if (__DEV__) {
     global.__modules.require(1005);
@@ -19,12 +23,8 @@ __ctx.module.exports.foo = 2;
 Object.assign(__ctx.module.exports, {
     bar: 1
 });
-const variable = 1;
 __x = variable;
-class Class {
-}
 __x1 = Class;
-function func() {}
 __x2 = func;
 __x3 = function() {
     global.__modules.require(1006);

--- a/packages/swc-plugin/transform/tests/fixture/paths/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/paths/output.js
@@ -26,10 +26,13 @@ __x3 = function() {
         global.__modules.require(1007);
     };
 };
-__x = 1;
-__x1 = class Class {
-};
-__x2 = function func() {};
+const variable = 1;
+__x = variable;
+class Class {
+}
+__x1 = Class;
+function func() {}
+__x2 = func;
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/paths/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/paths/output.js
@@ -19,13 +19,6 @@ __ctx.module.exports.foo = 2;
 Object.assign(__ctx.module.exports, {
     bar: 1
 });
-__x3 = function() {
-    global.__modules.require(1006);
-    const inner = async ()=>{
-        await global.__modules.require(1008);
-        global.__modules.require(1007);
-    };
-};
 const variable = 1;
 __x = variable;
 class Class {
@@ -33,6 +26,13 @@ class Class {
 __x1 = Class;
 function func() {}
 __x2 = func;
+__x3 = function() {
+    global.__modules.require(1006);
+    const inner = async ()=>{
+        await global.__modules.require(1008);
+        global.__modules.require(1007);
+    };
+};
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
@@ -9,6 +9,10 @@ var __mod1 = global.__modules.require("./re-exp-2");
 var __mod2 = global.__modules.require("./re-exp-3");
 var __mod3 = global.__modules.require("./re-exp-4");
 var __mod4 = global.__modules.require("./re-exp-5");
+const variable = 1;
+class Class {
+}
+function func() {}
 React.lazy(()=>global.__modules.require('./Component'));
 if (__DEV__) {
     global.__modules.require('./cjs-1');
@@ -19,12 +23,8 @@ __ctx.module.exports.foo = 2;
 Object.assign(__ctx.module.exports, {
     bar: 1
 });
-const variable = 1;
 __x = variable;
-class Class {
-}
 __x1 = Class;
-function func() {}
 __x2 = func;
 __x3 = function() {
     global.__modules.require('./cjs-2');

--- a/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
@@ -26,10 +26,13 @@ __x3 = function() {
         global.__modules.require('./cjs-3');
     };
 };
-__x = 1;
-__x1 = class Class {
-};
-__x2 = function func() {};
+const variable = 1;
+__x = variable;
+class Class {
+}
+__x1 = Class;
+function func() {}
+__x2 = func;
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/runtime/all/output.js
@@ -19,13 +19,6 @@ __ctx.module.exports.foo = 2;
 Object.assign(__ctx.module.exports, {
     bar: 1
 });
-__x3 = function() {
-    global.__modules.require('./cjs-2');
-    const inner = async ()=>{
-        await global.__modules.require('./esm');
-        global.__modules.require('./cjs-3');
-    };
-};
 const variable = 1;
 __x = variable;
 class Class {
@@ -33,6 +26,13 @@ class Class {
 __x1 = Class;
 function func() {}
 __x2 = func;
+__x3 = function() {
+    global.__modules.require('./cjs-2');
+    const inner = async ()=>{
+        await global.__modules.require('./esm');
+        global.__modules.require('./cjs-3');
+    };
+};
 __ctx.exports(function() {
     return {
         ...__ctx.exports.ns(__mod),

--- a/packages/swc-plugin/transform/tests/fixture/runtime/esm_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/runtime/esm_exports/output.js
@@ -1,10 +1,13 @@
 var __ctx = global.__modules.getContext(1000);
 const foo = 'foo';
 const bar = 'bar';
-__x = 1;
-__x1 = class Class {
-};
-__x2 = function func() {};
+const variable = 1;
+__x = variable;
+class Class {
+}
+__x1 = Class;
+function func() {}
+__x2 = func;
 __ctx.exports(function() {
     return {
         "foo": foo,

--- a/packages/swc-plugin/transform/tests/fixture/runtime/esm_exports/output.js
+++ b/packages/swc-plugin/transform/tests/fixture/runtime/esm_exports/output.js
@@ -1,12 +1,12 @@
 var __ctx = global.__modules.getContext(1000);
-const foo = 'foo';
-const bar = 'bar';
 const variable = 1;
-__x = variable;
 class Class {
 }
-__x1 = Class;
 function func() {}
+const foo = 'foo';
+const bar = 'bar';
+__x = variable;
+__x1 = Class;
 __x2 = func;
 __ctx.exports(function() {
     return {


### PR DESCRIPTION
```js
// AS-IS
__x = 1;
__x1 = class Class {
};
__x2 = function func() {};

// TO-BE
const variable = 1;
class Class {
}
function func() {}
__x = variable;
__x1 = Class;
__x2 = func;
```